### PR TITLE
Add basic front-end menu and screen navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,55 +1,55 @@
 <!doctype html>
-<html lang="ja">
+<html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <title>Dot Unit</title>
-  <style>
-    html, body {
-      height: 100%;
-      margin: 0;
-    }
-    #app {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-    }
-    #game-area {
-      flex: 1;
-      background: #222;
-      color: #fff;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      aspect-ratio: 16 / 9;
-      width: 100%;
-    }
-    #menu {
-      background: #444;
-      color: #fff;
-      padding: 8px;
-      display: flex;
-      justify-content: center;
-      gap: 1rem;
-    }
-    #menu button {
-      padding: 0.5rem 1rem;
-      font-size: 1rem;
-    }
-  </style>
+  <meta charset="utf-8">
+  <title>Dot-Unit</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="app">
-    <div id="game-area">
-      <p>Game view placeholder</p>
+  <section id="menu-screen" class="screen active">
+    <div class="menu-buttons">
+      <button data-target="battle-screen">Battle</button>
+      <button data-target="units-screen">Units</button>
+      <button data-target="items-screen">Items</button>
+      <button data-target="research-screen">Research</button>
+      <button data-target="options-screen">Options</button>
     </div>
-    <div id="menu">
+  </section>
+
+  <section id="battle-screen" class="screen">
+    <div id="game-area">Game Field</div>
+    <div class="battle-controls">
       <button>Move</button>
       <button>Attack</button>
       <button>Pass</button>
     </div>
-  </div>
-  <script type="module">
-    console.log('Dot Unit frontend placeholder');
-  </script>
+    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+  </section>
+
+  <section id="units-screen" class="screen">
+    <h2>Units</h2>
+    <p>Available units placeholder</p>
+    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+  </section>
+
+  <section id="items-screen" class="screen">
+    <h2>Items</h2>
+    <p>Items placeholder</p>
+    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+  </section>
+
+  <section id="research-screen" class="screen">
+    <h2>Research</h2>
+    <p>Research combinations placeholder</p>
+    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+  </section>
+
+  <section id="options-screen" class="screen">
+    <h2>Options</h2>
+    <p>Settings placeholder</p>
+    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+  </section>
+
+  <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const screens = document.querySelectorAll('.screen');
+
+  function showScreen(id) {
+    screens.forEach(screen => {
+      screen.classList.toggle('active', screen.id === id);
+    });
+  }
+
+  document.querySelectorAll('[data-target]').forEach(button => {
+    button.addEventListener('click', () => {
+      const target = button.getAttribute('data-target');
+      showScreen(target);
+    });
+  });
+
+  showScreen('menu-screen');
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,65 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  font-family: sans-serif;
+}
+
+.screen {
+  display: none;
+  height: 100%;
+}
+
+.screen.active {
+  display: flex;
+}
+
+#menu-screen {
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.menu-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+#battle-screen {
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 1rem;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+#game-area {
+  background: #222;
+  color: #fff;
+  width: 100%;
+  max-width: 960px;
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.battle-controls {
+  display: flex;
+  gap: 1rem;
+}
+
+.back-button {
+  margin-top: 1rem;
+}
+
+#units-screen,
+#items-screen,
+#research-screen,
+#options-screen {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}


### PR DESCRIPTION
## Summary
- Replace placeholder index with a menu-driven layout and individual screens
- Style with flexbox to center menu and maintain 16:9 game field
- Add vanilla JS screen switching for Battle, Units, Items, Research, and Options views

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63ae5a37c8321b90733e9bfbd39f8