### PR TITLE
Implement basic unit card UI with sorting and filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,46 @@
 
   <section id="units-screen" class="screen">
     <h2>Units</h2>
-    <p>Available units placeholder</p>
+    <div class="units-wrapper">
+      <div id="unit-grid" class="unit-grid"></div>
+      <aside id="unit-sidebar">
+        <h3>Owned Units</h3>
+        <p id="owned-count">0</p>
+      </aside>
+    </div>
+    <div class="units-controls">
+      <label>Sort
+        <select id="sort-select">
+          <option value="name">Name</option>
+          <option value="hp">HP</option>
+          <option value="mp">MP</option>
+          <option value="attack">Attack</option>
+          <option value="defense">Defense</option>
+          <option value="speed">Speed</option>
+        </select>
+      </label>
+      <label>Element
+        <select id="filter-element">
+          <option value="">All</option>
+          <option value="fire">Fire</option>
+          <option value="earth">Earth</option>
+          <option value="none">None</option>
+        </select>
+      </label>
+      <label>Race
+        <select id="filter-race">
+          <option value="">All</option>
+          <option value="human">Human</option>
+          <option value="beast">Beast</option>
+        </select>
+      </label>
+      <div class="pagination">
+        <button id="prev-page">Prev</button>
+        <span id="page-info">1/1</span>
+        <button id="next-page">Next</button>
+      </div>
+    </div>
+    <div id="unit-detail" class="unit-detail hidden"></div>
     <button class="back-button" data-target="menu-screen">Back to Menu</button>
   </section>
 

--- a/main.js
+++ b/main.js
@@ -15,4 +15,97 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   showScreen('menu-screen');
+
+  initUnitsScreen();
 });
+
+async function initUnitsScreen() {
+  const res = await fetch('data/units.json');
+  const data = await res.json();
+  const units = data.units;
+
+  const grid = document.getElementById('unit-grid');
+  const sidebarCount = document.getElementById('owned-count');
+  const sortSelect = document.getElementById('sort-select');
+  const filterElement = document.getElementById('filter-element');
+  const filterRace = document.getElementById('filter-race');
+  const prevPageBtn = document.getElementById('prev-page');
+  const nextPageBtn = document.getElementById('next-page');
+  const pageInfo = document.getElementById('page-info');
+  const detail = document.getElementById('unit-detail');
+
+  sidebarCount.textContent = units.length;
+
+  const perPage = 12;
+  let currentPage = 1;
+  let filtered = units.slice();
+
+  function sortUnits(list) {
+    const key = sortSelect.value;
+    return list.slice().sort((a, b) => {
+      if (key === 'name') return a.name.localeCompare(b.name);
+      return b[key] - a[key];
+    });
+  }
+
+  function applyFilters() {
+    filtered = units.filter(u => {
+      const el = filterElement.value;
+      const race = filterRace.value;
+      if (el && u.element !== el) return false;
+      if (race && u.race !== race) return false;
+      return true;
+    });
+    currentPage = 1;
+    render();
+  }
+
+  function render() {
+    const sorted = sortUnits(filtered);
+    const totalPages = Math.max(1, Math.ceil(sorted.length / perPage));
+    if (currentPage > totalPages) currentPage = totalPages;
+    pageInfo.textContent = `${currentPage}/${totalPages}`;
+    const start = (currentPage - 1) * perPage;
+    const pageUnits = sorted.slice(start, start + perPage);
+    grid.innerHTML = '';
+    pageUnits.forEach(u => {
+      const card = document.createElement('div');
+      card.className = 'unit-card';
+      card.innerHTML = `<strong>${u.name}</strong><br>HP: ${u.hp} MP: ${u.mp}`;
+      card.addEventListener('click', () => showDetails(u));
+      grid.appendChild(card);
+    });
+  }
+
+  function showDetails(unit) {
+    detail.innerHTML = `
+      <h3>${unit.name}</h3>
+      <p>HP: ${unit.hp}</p>
+      <p>MP: ${unit.mp}</p>
+      <p>Attack: ${unit.attack}</p>
+      <p>Defense: ${unit.defense}</p>
+      <p>Speed: ${unit.speed}</p>
+      <p>Race: ${unit.race}</p>
+      <p>Element: ${unit.element}</p>`;
+    detail.classList.remove('hidden');
+  }
+
+  sortSelect.addEventListener('change', render);
+  filterElement.addEventListener('change', applyFilters);
+  filterRace.addEventListener('change', applyFilters);
+  prevPageBtn.addEventListener('click', () => {
+    if (currentPage > 1) {
+      currentPage--;
+      render();
+    }
+  });
+  nextPageBtn.addEventListener('click', () => {
+    const totalPages = Math.max(1, Math.ceil(filtered.length / perPage));
+    if (currentPage < totalPages) {
+      currentPage++;
+      render();
+    }
+  });
+
+  applyFilters();
+}

--- a/style.css
+++ b/style.css
@@ -63,3 +63,62 @@ html, body {
   justify-content: center;
   gap: 1rem;
 }
+
+#units-screen {
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.units-wrapper {
+  display: flex;
+  width: 100%;
+  flex: 1;
+}
+
+.unit-grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.unit-card {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  background: #fff;
+  cursor: pointer;
+}
+
+#unit-sidebar {
+  width: 200px;
+  padding: 0.5rem;
+  border-left: 1px solid #ccc;
+  box-sizing: border-box;
+}
+
+.units-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin-top: 1rem;
+}
+
+.pagination {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.unit-detail {
+  width: 100%;
+  margin-top: 1rem;
+  border-top: 1px solid #ccc;
+  padding-top: 1rem;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- build unit screen with card grid, sidebar and details
- add sorting, filtering and pagination controls for units
- style unit screen layout and run through existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b64124d2cc83218e5cdff6c8b1cbb9