### PR TITLE
Add Japanese unit data and image handling

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -2,26 +2,26 @@
   "items": [
     {
       "id": "potion",
-      "name": "Healing Potion",
+      "name": "回復薬",
       "type": "consumable",
-      "effect": "Restore 20 HP to a unit.",
+      "effect": "HPを20回復する。",
       "drop_rate": 0.5,
       "value": 10
     },
     {
       "id": "amulet",
-      "name": "Lucky Amulet",
+      "name": "幸運のお守り",
       "type": "passive",
-      "effect": "Increase speed by 1.",
+      "effect": "速度が1上昇する。",
       "stackable": true,
       "drop_rate": 0.1,
       "value": 50
     },
     {
       "id": "sword",
-      "name": "Iron Sword",
+      "name": "鉄の剣",
       "type": "equipment",
-      "effect": "Increase attack by 5 when equipped.",
+      "effect": "装備すると攻撃力が5上昇する。",
       "drop_rate": 0.2,
       "value": 30
     }

--- a/data/skills.json
+++ b/data/skills.json
@@ -2,18 +2,18 @@
   "skills": [
     {
       "id": "slash",
-      "name": "Slash",
+      "name": "斬撃",
       "power": 8,
       "attribute": "physical",
-      "effect": "Deal damage to adjacent enemy.",
+      "effect": "隣接する敵にダメージを与える。",
       "range": 1
     },
     {
       "id": "fireball",
-      "name": "Fireball",
+      "name": "火球",
       "power": 9,
       "attribute": "fire",
-      "effect": "Deal fire damage at range.",
+      "effect": "離れた敵に火属性ダメージを与える。",
       "range": 2
     }
   ]

--- a/data/units.json
+++ b/data/units.json
@@ -2,7 +2,8 @@
   "units": [
     {
       "id": "hero",
-      "name": "Hero",
+      "name": "勇者",
+      "image": "images/units/hero.png",
       "hp": 28,
       "mp": 10,
       "attack": 9,
@@ -14,7 +15,8 @@
     },
     {
       "id": "mage",
-      "name": "Mage",
+      "name": "魔法使い",
+      "image": "images/units/mage.png",
       "hp": 18,
       "mp": 30,
       "attack": 6,
@@ -26,7 +28,8 @@
     },
     {
       "id": "goblin",
-      "name": "Goblin",
+      "name": "ゴブリン",
+      "image": "images/units/goblin.png",
       "hp": 22,
       "mp": 0,
       "attack": 7,
@@ -40,7 +43,8 @@
     },
     {
       "id": "orc",
-      "name": "Orc",
+      "name": "オーク",
+      "image": "images/units/orc.png",
       "hp": 38,
       "mp": 0,
       "attack": 11,

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="utf-8">
   <title>Dot-Unit</title>
@@ -8,85 +8,86 @@
 <body>
   <section id="menu-screen" class="screen active">
     <div class="menu-buttons">
-      <button data-target="battle-screen">Battle</button>
-      <button data-target="units-screen">Units</button>
-      <button data-target="items-screen">Items</button>
-      <button data-target="research-screen">Research</button>
-      <button data-target="options-screen">Options</button>
+      <button data-target="battle-screen">バトル</button>
+      <button data-target="units-screen">ユニット</button>
+      <button data-target="items-screen">アイテム</button>
+      <button data-target="research-screen">研究</button>
+      <button data-target="options-screen">設定</button>
     </div>
   </section>
 
   <section id="battle-screen" class="screen">
-    <div id="game-area">Game Field</div>
+    <div id="game-area">バトルフィールド</div>
     <div class="battle-controls">
-      <button>Move</button>
-      <button>Attack</button>
-      <button>Pass</button>
+      <button>移動</button>
+      <button>攻撃</button>
+      <button>待機</button>
     </div>
-    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+    <button class="back-button" data-target="menu-screen">メニューに戻る</button>
   </section>
 
   <section id="units-screen" class="screen">
-    <h2>Units</h2>
+    <h2>ユニット一覧</h2>
     <div class="units-wrapper">
       <div id="unit-grid" class="unit-grid"></div>
       <aside id="unit-sidebar">
-        <h3>Owned Units</h3>
+        <h3>所持ユニット</h3>
         <p id="owned-count">0</p>
       </aside>
     </div>
     <div class="units-controls">
-      <label>Sort
+      <label>並び替え
         <select id="sort-select">
-          <option value="name">Name</option>
+          <option value="name">名前</option>
           <option value="hp">HP</option>
           <option value="mp">MP</option>
-          <option value="attack">Attack</option>
-          <option value="defense">Defense</option>
-          <option value="speed">Speed</option>
+          <option value="attack">攻撃</option>
+          <option value="defense">防御</option>
+          <option value="speed">速度</option>
         </select>
       </label>
-      <label>Element
+      <label>属性
         <select id="filter-element">
-          <option value="">All</option>
-          <option value="fire">Fire</option>
-          <option value="earth">Earth</option>
-          <option value="none">None</option>
+          <option value="">すべて</option>
+          <option value="fire">火</option>
+          <option value="earth">土</option>
+          <option value="none">なし</option>
         </select>
       </label>
-      <label>Race
+      <label>種族
         <select id="filter-race">
-          <option value="">All</option>
-          <option value="human">Human</option>
-          <option value="beast">Beast</option>
+          <option value="">すべて</option>
+          <option value="human">人間</option>
+          <option value="beast">獣</option>
         </select>
       </label>
       <div class="pagination">
-        <button id="prev-page">Prev</button>
+        <button id="prev-page">前へ</button>
         <span id="page-info">1/1</span>
-        <button id="next-page">Next</button>
+        <button id="next-page">次へ</button>
       </div>
     </div>
+    <button id="formation-button">編成</button>
     <div id="unit-detail" class="unit-detail hidden"></div>
-    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+    <button class="back-button" data-target="menu-screen">メニューに戻る</button>
   </section>
 
   <section id="items-screen" class="screen">
-    <h2>Items</h2>
-    <p>Items placeholder</p>
-    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+    <h2>アイテム</h2>
+    <p>アイテムのプレースホルダー</p>
+    <button class="back-button" data-target="menu-screen">メニューに戻る</button>
   </section>
 
   <section id="research-screen" class="screen">
-    <h2>Research</h2>
-    <p>Research combinations placeholder</p>
-    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+    <h2>研究</h2>
+    <p>研究の組み合わせは準備中</p>
+    <button class="back-button" data-target="menu-screen">メニューに戻る</button>
   </section>
 
   <section id="options-screen" class="screen">
-    <h2>Options</h2>
-    <p>Settings placeholder</p>
-    <button class="back-button" data-target="menu-screen">Back to Menu</button>
+    <h2>設定</h2>
+    <p>設定のプレースホルダー</p>
+    <button class="back-button" data-target="menu-screen">メニューに戻る</button>
   </section>
 
   <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
   showScreen('menu-screen');
 
   initUnitsScreen();
+  initBattleScreen();
 });
 
 async function initUnitsScreen() {
@@ -33,6 +34,8 @@ async function initUnitsScreen() {
   const nextPageBtn = document.getElementById('next-page');
   const pageInfo = document.getElementById('page-info');
   const detail = document.getElementById('unit-detail');
+  const unitsControls = document.querySelector('.units-controls');
+  const formationBtn = document.getElementById('formation-button');
 
   sidebarCount.textContent = units.length;
 
@@ -71,23 +74,36 @@ async function initUnitsScreen() {
     pageUnits.forEach(u => {
       const card = document.createElement('div');
       card.className = 'unit-card';
-      card.innerHTML = `<strong>${u.name}</strong><br>HP: ${u.hp} MP: ${u.mp}`;
+      card.innerHTML = `
+        <img src="${u.image}" alt="${u.name}" class="unit-image">
+        <strong>${u.name}</strong><br>HP: ${u.hp} MP: ${u.mp}`;
       card.addEventListener('click', () => showDetails(u));
       grid.appendChild(card);
     });
   }
 
   function showDetails(unit) {
+    grid.classList.add('hidden');
+    unitsControls.classList.add('hidden');
+    formationBtn.classList.add('hidden');
     detail.innerHTML = `
+      <img src="${unit.image}" alt="${unit.name}" class="unit-image">
       <h3>${unit.name}</h3>
       <p>HP: ${unit.hp}</p>
       <p>MP: ${unit.mp}</p>
-      <p>Attack: ${unit.attack}</p>
-      <p>Defense: ${unit.defense}</p>
-      <p>Speed: ${unit.speed}</p>
-      <p>Race: ${unit.race}</p>
-      <p>Element: ${unit.element}</p>`;
+      <p>攻撃: ${unit.attack}</p>
+      <p>防御: ${unit.defense}</p>
+      <p>速度: ${unit.speed}</p>
+      <p>種族: ${unit.race}</p>
+      <p>属性: ${unit.element}</p>
+      <button id="back-to-list">一覧に戻る</button>`;
     detail.classList.remove('hidden');
+    document.getElementById('back-to-list').addEventListener('click', () => {
+      detail.classList.add('hidden');
+      grid.classList.remove('hidden');
+      unitsControls.classList.remove('hidden');
+      formationBtn.classList.remove('hidden');
+    });
   }
 
   sortSelect.addEventListener('change', render);
@@ -108,4 +124,24 @@ async function initUnitsScreen() {
   });
 
   applyFilters();
+}
+
+async function initBattleScreen() {
+  const res = await fetch('data/units.json');
+  const data = await res.json();
+  const units = data.units;
+  const hero = units.find(u => u.id === 'hero');
+  const enemy = units.find(u => u.id === 'goblin');
+  const area = document.getElementById('game-area');
+  area.innerHTML = '';
+  const heroImg = document.createElement('img');
+  heroImg.src = hero.image;
+  heroImg.alt = hero.name;
+  heroImg.className = 'unit-image player-unit';
+  const enemyImg = document.createElement('img');
+  enemyImg.src = enemy.image;
+  enemyImg.alt = enemy.name;
+  enemyImg.className = 'unit-image';
+  area.appendChild(heroImg);
+  area.appendChild(enemyImg);
 }

--- a/style.css
+++ b/style.css
@@ -91,6 +91,16 @@ html, body {
   cursor: pointer;
 }
 
+.unit-image {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.player-unit {
+  transform: scaleX(-1);
+}
+
 #unit-sidebar {
   width: 200px;
   padding: 0.5rem;


### PR DESCRIPTION
## Summary
- Translate visible UI text and data to Japanese
- Link unit images and show them in unit list and battle preview
- Add formation button and detail view with back navigation
- Flip player unit images horizontally in battles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b644d360148321819bec5537cde512