### PR TITLE
Add unit ranks, equipment limits, and boss skills

### DIFF
--- a/data/boss_skills.json
+++ b/data/boss_skills.json
@@ -1,0 +1,12 @@
+{
+  "skills": [
+    {
+      "id": "earthquake",
+      "name": "アースクエイク",
+      "power": 12,
+      "attribute": "earth",
+      "effect": "全ての敵に土属性ダメージを与える。",
+      "range": 3
+    }
+  ]
+}

--- a/data/items.json
+++ b/data/items.json
@@ -11,9 +11,9 @@
     {
       "id": "amulet",
       "name": "幸運のお守り",
-      "type": "passive",
-      "effect": "速度が1上昇する。",
-      "stackable": true,
+      "type": "equipment",
+      "slot": "artifact",
+      "effect": "装備すると速度が1上昇する。",
       "drop_rate": 0.1,
       "value": 50
     },
@@ -21,6 +21,8 @@
       "id": "sword",
       "name": "鉄の剣",
       "type": "equipment",
+      "slot": "weapon",
+      "range_type": "melee",
       "effect": "装備すると攻撃力が5上昇する。",
       "drop_rate": 0.2,
       "value": 30

--- a/data/units.json
+++ b/data/units.json
@@ -11,6 +11,11 @@
       "speed": 5,
       "race": "human",
       "element": "none",
+      "rank": "S",
+      "weaponSlots": 2,
+      "artifactSlots": 1,
+      "weaponTypes": ["melee", "mid"],
+      "acquired": true,
       "skills": ["slash"]
     },
     {
@@ -24,6 +29,11 @@
       "speed": 7,
       "race": "human",
       "element": "fire",
+      "rank": "A",
+      "weaponSlots": 1,
+      "artifactSlots": 2,
+      "weaponTypes": ["mid", "ranged"],
+      "acquired": true,
       "skills": ["fireball"]
     },
     {
@@ -37,8 +47,16 @@
       "speed": 4,
       "race": "beast",
       "element": "earth",
+      "rank": "C",
+      "weaponSlots": 1,
+      "artifactSlots": 0,
+      "weaponTypes": ["melee"],
+      "acquired": false,
       "skills": ["slash"],
-      "drop": "potion",
+      "drops": [
+        {"item": "potion", "rate": 0.5},
+        {"item": "amulet", "rate": 0.1}
+      ],
       "reward": {"gold": 5, "exp": 3}
     },
     {
@@ -52,8 +70,16 @@
       "speed": 3,
       "race": "beast",
       "element": "earth",
+      "rank": "B",
+      "weaponSlots": 1,
+      "artifactSlots": 0,
+      "weaponTypes": ["melee", "mid"],
+      "acquired": false,
       "skills": ["slash"],
-      "drop": "sword",
+      "drops": [
+        {"item": "sword", "rate": 0.2},
+        {"item": "potion", "rate": 0.3}
+      ],
       "reward": {"gold": 12, "exp": 5}
     }
   ]

--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
 async function initMenuUnits() {
   const res = await fetch('data/units.json');
   const data = await res.json();
-  const units = data.units;
+  const units = data.units.filter(u => u.acquired);
   const container = document.getElementById('menu-moving-units');
   const width = container.clientWidth || 960;
 
@@ -52,32 +52,41 @@ async function initUnitsScreen() {
   const grid = document.getElementById('unit-grid');
   const detail = document.getElementById('unit-detail');
 
-  const displayUnits = units.slice();
-  while (displayUnits.length < 12) {
-    displayUnits.push(units[displayUnits.length % units.length]);
-  }
-
-  displayUnits.slice(0, 12).forEach(unit => {
+  units.forEach(unit => {
     const card = document.createElement('div');
     card.className = 'unit-card';
+    const name = unit.acquired ? unit.name : '???';
     card.innerHTML = `
       <img src="${unit.image}" alt="${unit.name}" class="unit-image">
-      <strong>${unit.name}</strong>`;
+      <strong>${name}</strong>`;
     card.addEventListener('click', () => showDetail(unit));
     grid.appendChild(card);
   });
 
   function showDetail(unit) {
     grid.classList.add('hidden');
-    detail.innerHTML = `
-      <img src="${unit.image}" alt="${unit.name}" class="unit-image">
-      <h3>${unit.name}</h3>
-      <p>HP: ${unit.hp}</p>
-      <p>MP: ${unit.mp}</p>
-      <p>攻撃: ${unit.attack}</p>
-      <p>防御: ${unit.defense}</p>
-      <p>速度: ${unit.speed}</p>
-      <button id="back-to-list">一覧に戻る</button>`;
+    if (unit.acquired) {
+      const drops = unit.drops ? unit.drops.map(d => `${d.item}(${d.rate})`).join(', ') : 'なし';
+      detail.innerHTML = `
+        <img src="${unit.image}" alt="${unit.name}" class="unit-image">
+        <h3>${unit.name}</h3>
+        <p>ランク: ${unit.rank}</p>
+        <p>HP: ${unit.hp}</p>
+        <p>MP: ${unit.mp}</p>
+        <p>攻撃: ${unit.attack}</p>
+        <p>防御: ${unit.defense}</p>
+        <p>速度: ${unit.speed}</p>
+        <p>武器スロット: ${unit.weaponSlots}</p>
+        <p>アーティファクトスロット: ${unit.artifactSlots}</p>
+        <p>装備可能武器タイプ: ${unit.weaponTypes.join(', ')}</p>
+        <p>ドロップ: ${drops}</p>
+        <button id="back-to-list">一覧に戻る</button>`;
+    } else {
+      detail.innerHTML = `
+        <h3>???</h3>
+        <p>未取得のユニットです。</p>
+        <button id="back-to-list">一覧に戻る</button>`;
+    }
     detail.classList.remove('hidden');
     document.getElementById('back-to-list').addEventListener('click', () => {
       detail.classList.add('hidden');

--- a/src/items/index.js
+++ b/src/items/index.js
@@ -54,10 +54,30 @@ class ItemManager {
   }
 
   applyEquipment(item, unit) {
-    if (!unit.equipment) unit.equipment = {};
-    unit.equipment[item.id] = item;
-    if (item.id === 'sword') {
-      unit.attack = (unit.attack || 0) + 5;
+    if (!unit.equipment) unit.equipment = { weapons: [], artifacts: [], others: {} };
+    const slot = item.slot;
+    if (slot === 'weapon') {
+      unit.equipment.weapons = unit.equipment.weapons || [];
+      const max = unit.weaponSlots || 0;
+      if (unit.equipment.weapons.length >= max) {
+        throw new Error('No weapon slots left');
+      }
+      unit.equipment.weapons.push(item);
+      if (item.id === 'sword') {
+        unit.attack = (unit.attack || 0) + 5;
+      }
+    } else if (slot === 'artifact') {
+      unit.equipment.artifacts = unit.equipment.artifacts || [];
+      const max = unit.artifactSlots || 0;
+      if (unit.equipment.artifacts.length >= max) {
+        throw new Error('No artifact slots left');
+      }
+      unit.equipment.artifacts.push(item);
+      if (item.id === 'amulet') {
+        unit.speed = (unit.speed || 0) + 1;
+      }
+    } else {
+      unit.equipment.others[item.id] = item;
     }
   }
 }

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -25,18 +25,24 @@ async function loadItems() {
   return loadJSON('items.json');
 }
 
+async function loadBossSkills() {
+  return loadJSON('boss_skills.json');
+}
+
 async function loadAll() {
-  const [units, skills, items] = await Promise.all([
+  const [units, skills, items, bossSkills] = await Promise.all([
     loadUnits(),
     loadSkills(),
-    loadItems()
+    loadItems(),
+    loadBossSkills()
   ]);
-  return { units, skills, items };
+  return { units, skills, items, bossSkills };
 }
 
 module.exports = {
   loadUnits,
   loadSkills,
   loadItems,
+  loadBossSkills,
   loadAll
 };

--- a/src/units/UnitManager.js
+++ b/src/units/UnitManager.js
@@ -10,9 +10,8 @@ class UnitManager {
   async init() {
     const data = await loadUnits();
     this.units = data.units;
-    if (this.units.length && this.unlocked.size === 0) {
-      // unlock the first unit by default
-      this.unlocked.add(this.units[0].id);
+    if (this.unlocked.size === 0) {
+      this.units.filter(u => u.acquired).forEach(u => this.unlocked.add(u.id));
     }
   }
 

--- a/tests/test_json_validation.py
+++ b/tests/test_json_validation.py
@@ -87,7 +87,18 @@ UNIT_SCHEMA = {
                     "race": {"type": "string"},
                     "element": {"type": "string"},
                     "skills": {"type": "array"},
-                    "drop": {"type": "string"},
+                    "drops": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["item", "rate"],
+                            "properties": {
+                                "item": {"type": "string"},
+                                "rate": {"type": "number"}
+                            },
+                            "additionalProperties": False
+                        }
+                    },
                     "reward": {
                         "type": "object",
                         "properties": {
@@ -117,3 +128,7 @@ def test_skills_schema():
 
 def test_units_schema():
     Draft7Validator(UNIT_SCHEMA).validate(load("data/units.json"))
+
+
+def test_boss_skills_schema():
+    Draft7Validator(SKILL_SCHEMA).validate(load("data/boss_skills.json"))


### PR DESCRIPTION
## Summary
- add rank, equipment slot counts and weapon-type restrictions to unit data
- support multiple item drops with probabilities and mark Goblin/Orc as unacquired
- introduce boss skills dataset and loader support

## Testing
- `pip install jsonschema`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6542058ac83218b9e769c99a42610