### PR TITLE
Enhance menu visuals and unit animation

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,11 +13,22 @@ document.addEventListener('DOMContentLoaded', () => {
       showScreen(target);
     });
   });
-
+  setRandomMenuBackground();
   showScreen('menu-screen');
   initUnitsScreen();
   initMenuUnits();
 });
+
+function setRandomMenuBackground() {
+  const menu = document.getElementById('menu-screen');
+  const images = [];
+  for (let i = 1; i <= 10; i++) {
+    const num = String(i).padStart(2, '0');
+    images.push(`images/fields/${num}.png`);
+  }
+  const img = images[Math.floor(Math.random() * images.length)];
+  menu.style.backgroundImage = `url(${img})`;
+}
 
 async function initMenuUnits() {
   const res = await fetch('data/units.json');
@@ -34,12 +45,14 @@ async function initMenuUnits() {
     img.style.left = x + 'px';
     container.appendChild(img);
     let dir = Math.random() < 0.5 ? -1 : 1;
+    img.style.transform = dir === -1 ? 'scaleX(-1)' : 'scaleX(1)';
     const speed = 0.5 + Math.random();
     setInterval(() => {
       let pos = parseFloat(img.style.left);
       pos += dir * speed;
       if (pos < -50 || pos > width) {
         dir *= -1;
+        img.style.transform = dir === -1 ? 'scaleX(-1)' : 'scaleX(1)';
       }
       img.style.left = pos + 'px';
     }, 20);

--- a/style.css
+++ b/style.css
@@ -31,6 +31,11 @@ html, body {
   justify-content: center;
 }
 
+#menu-screen {
+  background-size: cover;
+  background-position: center;
+}
+
 .game-title {
   position: absolute;
   top: 0.5rem;
@@ -45,9 +50,26 @@ html, body {
   gap: 0.5rem;
 }
 
+.menu-buttons button {
+  background: #444;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1.25rem;
+  font-size: 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: background 0.3s, transform 0.1s;
+}
+
+.menu-buttons button:hover {
+  background: #666;
+  transform: translateY(-2px);
+}
+
 #menu-moving-units {
   position: absolute;
-  bottom: 0;
+  bottom: 5px;
   left: 0;
   width: 100%;
   height: 80px;


### PR DESCRIPTION
## Summary
- Apply sleek styling to menu buttons and elevate moving units slightly from screen bottom
- Add random field backgrounds for menu screen and flip units when moving left

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b656a34f1883219aeda0817e50c32f