### PR TITLE
Add race filtering, Japanese labels, and card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,10 +32,20 @@
             <select id="sort-select">
               <option value="name">名前</option>
               <option value="rank">ランク</option>
+              <option value="hp">HP</option>
+              <option value="mp">MP</option>
+              <option value="attack">攻撃力</option>
+              <option value="defense">防御力</option>
+              <option value="speed">スピード</option>
             </select>
           </label>
           <label>属性
             <select id="filter-select">
+              <option value="all">全て</option>
+            </select>
+          </label>
+          <label>種族
+            <select id="race-filter">
               <option value="all">全て</option>
             </select>
           </label>

--- a/main.js
+++ b/main.js
@@ -67,6 +67,7 @@ async function initUnitsScreen() {
   const countsDiv = document.getElementById('unit-counts');
   const sortSelect = document.getElementById('sort-select');
   const filterSelect = document.getElementById('filter-select');
+  const raceFilter = document.getElementById('race-filter');
   const pagination = document.getElementById('pagination');
   const footer = document.getElementById('units-footer');
 
@@ -80,14 +81,41 @@ async function initUnitsScreen() {
 
   sortSelect.addEventListener('change', applySortFilter);
   filterSelect.addEventListener('change', applySortFilter);
+  raceFilter.addEventListener('change', applySortFilter);
+
+  const elementNames = {
+    none: '無',
+    fire: '火',
+    water: '水',
+    wind: '風',
+    earth: '土',
+    light: '光',
+    dark: '闇'
+  };
+  const raceNames = {
+    human: '人間',
+    beast: '獣',
+    dragon: 'ドラゴン',
+    undead: 'アンデッド',
+    demon: '悪魔',
+    machine: '機械',
+    plant: '植物'
+  };
 
   function populateFilterOptions() {
     const elements = [...new Set(units.map(u => u.element))];
     elements.forEach(el => {
       const opt = document.createElement('option');
       opt.value = el;
-      opt.textContent = el;
+      opt.textContent = elementNames[el] || el;
       filterSelect.appendChild(opt);
+    });
+    const races = [...new Set(units.map(u => u.race))];
+    races.forEach(rc => {
+      const opt = document.createElement('option');
+      opt.value = rc;
+      opt.textContent = raceNames[rc] || rc;
+      raceFilter.appendChild(opt);
     });
   }
 
@@ -99,20 +127,25 @@ async function initUnitsScreen() {
       if (u.acquired) counts[u.element].acquired++;
     });
     countsDiv.innerHTML = Object.entries(counts)
-      .map(([el, c]) => `${el}: ${c.acquired}/${c.total}`)
+      .map(([el, c]) => `${elementNames[el] || el}: ${c.acquired}/${c.total}`)
       .join(' ');
   }
 
   function applySortFilter() {
     const sort = sortSelect.value;
-    const filter = filterSelect.value;
+    const elementFilter = filterSelect.value;
+    const race = raceFilter.value;
     let list = [...units];
-    if (filter !== 'all') {
-      list = list.filter(u => u.element === filter);
+    if (elementFilter !== 'all') {
+      list = list.filter(u => u.element === elementFilter);
+    }
+    if (race !== 'all') {
+      list = list.filter(u => u.race === race);
     }
     list.sort((a, b) => {
       if (sort === 'name') return a.name.localeCompare(b.name);
       if (sort === 'rank') return rankValue(b.rank) - rankValue(a.rank);
+      if (['hp', 'mp', 'attack', 'defense', 'speed'].includes(sort)) return b[sort] - a[sort];
       return 0;
     });
     filteredUnits = list;
@@ -165,8 +198,9 @@ async function initUnitsScreen() {
       ? `HP:${unit.hp} MP:${unit.mp} <br>攻:${unit.attack} 防:${unit.defense} 速:${unit.speed}`
       : '';
     const stars = '★'.repeat(rankValue(unit.rank));
+    const imgClass = unit.acquired ? 'unit-image' : 'unit-image silhouette';
     card.innerHTML = `
-      <img src="${unit.image}" alt="${unit.name}" class="unit-image">
+      <img src="${unit.image}" alt="${unit.name}" class="${imgClass}">
       <div class="unit-info">
         <div class="unit-top">
           <div class="unit-rank">${stars}</div>
@@ -188,6 +222,8 @@ async function initUnitsScreen() {
         <img src="${unit.image}" alt="${unit.name}" class="unit-image">
         <h3>${unit.name}</h3>
         <p>ランク: ${unit.rank}</p>
+        <p>種族: ${raceNames[unit.race] || unit.race}</p>
+        <p>属性: ${elementNames[unit.element] || unit.element}</p>
         <p>HP: ${unit.hp}</p>
         <p>MP: ${unit.mp}</p>
         <p>攻撃: ${unit.attack}</p>

--- a/style.css
+++ b/style.css
@@ -110,7 +110,8 @@ html, body {
 
 .unit-card {
   border: 1px solid #ccc;
-  background: #fff;
+  background: #575455;
+  color: #fff;
   padding: 0.5rem;
   display: flex;
   gap: 0.5rem;
@@ -122,6 +123,10 @@ html, body {
   height: 64px;
   object-fit: contain;
   object-position: bottom;
+}
+
+.unit-image.silhouette {
+  filter: brightness(0);
 }
 
 .unit-info {
@@ -166,6 +171,20 @@ html, body {
   font-size: 0.9rem;
 }
 
+.sort-filter select {
+  background: #444;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.sort-filter select:hover {
+  background: #666;
+}
+
 .pagination {
   display: flex;
   align-items: center;
@@ -178,4 +197,17 @@ html, body {
 
 .back-button {
   margin: 0;
+  background: #444;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: background 0.3s, transform 0.1s;
+}
+
+.back-button:hover {
+  background: #666;
+  transform: translateY(-2px);
 }


### PR DESCRIPTION
## Summary
- Add HP/MP/attack/defense/speed sorting and race filter for unit list
- Translate element and race names to Japanese and show silhouette for unknown units
- Restyle unit cards and buttons with dark theme

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b66b3034c483219b9fc306d705f8eb