### PR TITLE
Add toggle for unacquired units and formation button

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
               <option value="all">属性</option>
             </select>
           </label>
+          <button id="toggle-unacquired">未取得非表示</button>
           <label>
             <select id="race-filter">
               <option value="all">種族</option>
@@ -51,7 +52,10 @@
           </label>
         </div>
         <div id="pagination" class="pagination"></div>
-        <button class="back-button" data-target="menu-screen">メニューに戻る</button>
+        <div class="footer-buttons">
+          <button id="formation-button" class="back-button">編成</button>
+          <button class="back-button" data-target="menu-screen">メニューに戻る</button>
+        </div>
       </div>
     </section>
 

--- a/main.js
+++ b/main.js
@@ -77,12 +77,14 @@ async function initUnitsScreen() {
   const sortSelect = document.getElementById('sort-select');
   const filterSelect = document.getElementById('filter-select');
   const raceFilter = document.getElementById('race-filter');
+  const toggleUnacquired = document.getElementById('toggle-unacquired');
   const pagination = document.getElementById('pagination');
   const footer = document.getElementById('units-footer');
 
   const itemsPerPage = 15;
   let currentPage = 1;
   let filteredUnits = [...units];
+  let showUnacquired = true;
 
   const elementNames = {
     none: '無',
@@ -110,6 +112,11 @@ async function initUnitsScreen() {
   sortSelect.addEventListener('change', applySortFilter);
   filterSelect.addEventListener('change', applySortFilter);
   raceFilter.addEventListener('change', applySortFilter);
+  toggleUnacquired.addEventListener('click', () => {
+    showUnacquired = !showUnacquired;
+    toggleUnacquired.textContent = showUnacquired ? '未取得非表示' : '未取得表示';
+    applySortFilter();
+  });
 
   function populateFilterOptions() {
     const elements = [...new Set(units.map(u => u.element))];
@@ -150,6 +157,9 @@ async function initUnitsScreen() {
     }
     if (race !== 'all') {
       list = list.filter(u => u.race === race);
+    }
+    if (!showUnacquired) {
+      list = list.filter(u => u.acquired);
     }
     list.sort((a, b) => {
       if (sort === 'name') return a.name.localeCompare(b.name);

--- a/style.css
+++ b/style.css
@@ -253,9 +253,28 @@ html, body {
   background: #666;
 }
 
+.sort-filter button {
+  background: #444;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.sort-filter button:hover {
+  background: #666;
+}
+
 .pagination {
   display: flex;
   align-items: center;
+  gap: 0.5rem;
+}
+
+.footer-buttons {
+  display: flex;
   gap: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- Add button to show or hide unacquired units next to filters
- Add formation button beside return-to-menu
- Style updates for new controls and logic for filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b677ef93548321b6687abd1e2d6e2d