### PR TITLE
Hide unit selection overlay when hidden

### DIFF
--- a/style.css
+++ b/style.css
@@ -420,6 +420,10 @@ html, body {
   justify-content: center;
 }
 
+#unit-selection.hidden {
+  display: none;
+}
+
 #unit-selection .unit-selection-content {
   background: #fff;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- hide unit selection overlay when `.hidden` class is present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6966fea7c8321948913c0ff37eeaa