### PR TITLE
Adjust formation field to fit game container

### DIFF
--- a/style.css
+++ b/style.css
@@ -353,14 +353,14 @@ html, body {
 .formation-main {
   position: relative;
   width: 940px;
-  height: 540px;
+  height: calc(100% - 60px);
   margin: 0 auto;
 }
 
 #formation-field {
   position: relative;
   width: 940px;
-  height: 540px;
+  height: 100%;
   background-image: url('images/fields/01.png');
   background-size: cover;
 }


### PR DESCRIPTION
## Summary
- Ensure formation screen's main section accounts for header height
- Let formation field stretch to fill available height so entire 5x13 grid shows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6974a27388321adc545d5bd571640