### PR TITLE
Revamp formation screen layout and unit selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,9 +83,6 @@
           </div>
         </div>
       </div>
-      <div id="unit-selection" class="hidden">
-        <div class="unit-selection-content"></div>
-      </div>
     </section>
 
     <section id="battle-screen" class="screen">

--- a/style.css
+++ b/style.css
@@ -118,6 +118,11 @@ html, body {
   cursor: pointer;
 }
 
+.unit-card.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .unit-card.rank-1 {
   background: #ffffff;
   color: #000;
@@ -302,6 +307,8 @@ html, body {
 #formation-screen {
   align-items: flex-start;
   justify-content: flex-start;
+  background-image: url('images/fields/01.png');
+  background-size: cover;
 }
 
 .formation-top {
@@ -352,35 +359,33 @@ html, body {
 
 .formation-main {
   position: relative;
-  width: 940px;
+  width: 960px;
   height: calc(100% - 60px);
-  margin: 0 auto;
+  margin: 0;
 }
 
 #formation-field {
   position: relative;
-  width: 940px;
+  width: 960px;
   height: 100%;
-  background-image: url('images/fields/01.png');
-  background-size: cover;
 }
 
 #formation-grid {
   position: absolute;
-  left: 2px;
-  bottom: 2px;
-  width: 936px;
-  height: 360px;
+  left: 156px;
+  top: 2px;
+  width: 648px;
+  height: 288px;
   display: grid;
-  grid-template-columns: repeat(13, 72px);
-  grid-template-rows: repeat(5, 72px);
+  grid-template-columns: repeat(9, 72px);
+  grid-template-rows: repeat(4, 72px);
 }
 
 #formation-left {
   position: absolute;
   top: 0;
   left: 0;
-  width: 200px;
+  width: 150px;
   padding: 0.5rem;
   box-sizing: border-box;
   display: flex;
@@ -408,34 +413,7 @@ html, body {
   object-fit: contain;
 }
 
-#unit-selection {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.player-unit {
+  transform: scaleX(-1);
 }
 
-#unit-selection.hidden {
-  display: none;
-}
-
-#unit-selection .unit-selection-content {
-  background: #fff;
-  padding: 1rem;
-  max-height: 80%;
-  overflow: auto;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-#unit-selection img {
-  width: 48px;
-  height: 48px;
-  cursor: pointer;
-}


### PR DESCRIPTION
## Summary
- Resize formation grid to 4x9 starting at x156,y2 and apply full-screen background
- Select units via unit list screen, prevent duplicates, and allow removal from formation
- Mirror player unit images and show unit stats on hover

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b69a9d88c88321b8a4a4717c431433