### PR TITLE
Fix unit detail showing stray unit-info label

### DIFF
--- a/main.js
+++ b/main.js
@@ -393,7 +393,7 @@ async function initFormationScreen() {
     const item = document.createElement('div');
     item.className = 'unit-slide-item';
     item.draggable = true;
-    item.innerHTML = `<img src="${u.image}" alt="${u.name}"><div class="unit-info">R${u.rank} ${u.name} Lv${u.level}</div>`;
+    item.innerHTML = `<img src="${u.image}" alt="${u.name}"><div class="unit-slide-info">R${u.rank} ${u.name} Lv${u.level}</div>`;
     item.addEventListener('dragstart', e => {
       e.dataTransfer.setData('unit', JSON.stringify(u));
     });

--- a/style.css
+++ b/style.css
@@ -423,7 +423,7 @@ html, body {
   object-fit: contain;
 }
 
-.unit-info {
+.unit-slide-info {
   position: absolute;
   bottom: 0;
   left: 50%;


### PR DESCRIPTION
## Summary
- Avoid conflict with unit list styling by renaming formation slide's `unit-info` class to `unit-slide-info`
- Update formation slide DOM to use the new class

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6a1e342a08321b50850c6523c932e