### PR TITLE
Revamp formation UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,8 +78,10 @@
           <div id="formation-grid"></div>
           <div id="formation-left">
             <div id="synergy">シナジー: なし</div>
-            <div id="selected-unit-stats">ユニット未選択</div>
             <div id="player-status"></div>
+          </div>
+          <div id="formation-right">
+            <div id="selected-unit-stats">ユニット未選択</div>
           </div>
         </div>
         <div id="unit-slide" class="unit-slide"></div>

--- a/main.js
+++ b/main.js
@@ -393,7 +393,14 @@ async function initFormationScreen() {
     const item = document.createElement('div');
     item.className = 'unit-slide-item';
     item.draggable = true;
-    item.innerHTML = `<img src="${u.image}" alt="${u.name}"><div class="unit-slide-info">R${u.rank} ${u.name} Lv${u.level}</div>`;
+    const stars = '★'.repeat(Number(u.rank));
+    const name = u.name.length > 6 ? u.name.slice(0, 6) : u.name;
+    item.innerHTML = `
+      <img src="${u.image}" alt="${u.name}">
+      <div class="unit-level">Lv${u.level}</div>
+      <div class="unit-stars">${stars}</div>
+      <div class="unit-slide-name">${name}</div>
+    `;
     item.addEventListener('dragstart', e => {
       e.dataTransfer.setData('unit', JSON.stringify(u));
     });
@@ -533,8 +540,7 @@ async function initFormationScreen() {
       <h4>${player.name}</h4>
       <p>Lv:${player.level}</p>
       <p>配置可能:${player.maxUnits}</p>
-      <p>ステ上昇 HP:${player.bonuses.hp}% MP:${player.bonuses.mp}%<br>攻:${player.bonuses.attack}% 防:${player.bonuses.defense}% 速:${player.bonuses.speed}%</p>
-      <p>ゴールド:${player.gold}</p>`;
+      <p>ステ上昇 HP:${player.bonuses.hp}% MP:${player.bonuses.mp}%<br>攻:${player.bonuses.attack}% 防:${player.bonuses.defense}% 速:${player.bonuses.speed}%</p>`;
   }
 
   window.loadFormationGrid = loadGrid;

--- a/style.css
+++ b/style.css
@@ -396,6 +396,21 @@ html, body {
   color: #fff;
 }
 
+#formation-right {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 150px;
+  height: 288px;
+  padding: 0.5rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+}
+
 #unit-slide {
   position: absolute;
   top: 295px;
@@ -421,9 +436,31 @@ html, body {
   width: 100%;
   height: 100%;
   object-fit: contain;
+  transform: scaleX(-1);
 }
 
-.unit-slide-info {
+.unit-level {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 0.7rem;
+  padding: 1px 2px;
+}
+
+.unit-stars {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: #ffd700;
+  font-size: 0.7rem;
+  padding: 1px 2px;
+}
+
+.unit-slide-name {
   position: absolute;
   bottom: 0;
   left: 50%;


### PR DESCRIPTION
## Summary
- Move selected unit stats to a new right-side panel on the formation screen and drop gold display.
- Mirror unit-slide images leftward and overlay level, rank stars, and unit name (max 6 characters).
- Add supporting styles for flipped images and new overlays.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6a5edbed88321a02aa5e233aa5682