### PR TITLE
Use stage background images

### DIFF
--- a/main.js
+++ b/main.js
@@ -37,7 +37,7 @@ function setRandomMenuBackground() {
   const images = [];
   for (let i = 1; i <= 10; i++) {
     const num = String(i).padStart(2, '0');
-    images.push(`images/fields/${num}.png`);
+    images.push(`images/stages/stage_${num}.png`);
   }
   const img = images[Math.floor(Math.random() * images.length)];
   menu.style.backgroundImage = `url(${img})`;

--- a/style.css
+++ b/style.css
@@ -307,7 +307,7 @@ html, body {
 #formation-screen {
   align-items: flex-start;
   justify-content: flex-start;
-  background-image: url('images/fields/01.png');
+  background-image: url('images/stages/stage_01.png');
   background-size: cover;
 }
 


### PR DESCRIPTION
## Summary
- Replace old field images with new stage images for menu backgrounds and formation screen

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6adbf8390832191bf44130b354b31