### PR TITLE
Add world map with field selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,27 @@
     <section id="menu-screen" class="screen active">
       <h1 class="game-title">Dot-Unit</h1>
       <div class="menu-buttons">
-        <button data-target="battle-screen">バトル</button>
+        <button data-target="world-screen">バトル</button>
         <button data-target="units-screen">ユニット一覧</button>
         <button data-target="items-screen">アイテム一覧</button>
         <button data-target="research-screen">研究</button>
         <button data-target="options-screen">設定</button>
       </div>
       <div id="menu-moving-units"></div>
+    </section>
+
+    <section id="world-screen" class="screen">
+      <div id="world-map-container">
+        <button class="field-button" data-field="1" style="top: 240px; left: 220px;">始まりの島</button>
+        <button class="field-button" data-field="2" style="top: 160px; left: 520px;">？？？</button>
+      </div>
+      <button class="back-button" data-target="menu-screen">メニューに戻る</button>
+    </section>
+
+    <section id="field-screen" class="screen">
+      <h2 id="field-name"></h2>
+      <img id="field-image" alt="field">
+      <button class="back-button" data-target="world-screen">ワールドに戻る</button>
     </section>
 
     <section id="units-screen" class="screen">

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
       screen.classList.toggle('active', screen.id === id);
     });
   }
+  window.showScreen = showScreen;
 
   document.querySelectorAll('[data-target]').forEach(button => {
     button.addEventListener('click', () => {
@@ -30,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initUnitsScreen();
   initMenuUnits();
   initFormationScreen();
+  initWorldScreen();
 });
 
 function setRandomMenuBackground() {
@@ -587,4 +589,32 @@ async function initFormationScreen() {
   }
 
   window.loadFormationGrid = loadGrid;
+}
+
+function initWorldScreen() {
+  const defaultAccess = { 1: true, 2: false };
+  const access = JSON.parse(localStorage.getItem('fieldAccess')) || defaultAccess;
+  if (!localStorage.getItem('fieldAccess')) {
+    localStorage.setItem('fieldAccess', JSON.stringify(access));
+  }
+  const buttons = document.querySelectorAll('#world-map-container .field-button');
+  buttons.forEach(btn => {
+    const id = btn.dataset.field;
+    if (!access[id]) {
+      btn.classList.add('locked');
+    }
+    btn.addEventListener('click', () => {
+      if (!access[id]) return;
+      selectField(id, btn.textContent);
+    });
+  });
+}
+
+function selectField(id, name) {
+  const num = String(id).padStart(2, '0');
+  const img = document.getElementById('field-image');
+  const title = document.getElementById('field-name');
+  if (img) img.src = `images/stages/field_${num}.png`;
+  if (title) title.textContent = name;
+  window.showScreen('field-screen');
 }

--- a/style.css
+++ b/style.css
@@ -504,3 +504,30 @@ html, body {
   transform: scaleX(-1);
 }
 
+#world-screen {
+  justify-content: flex-start;
+}
+
+#world-map-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-image: url('images/stages/world_01.png');
+  background-size: cover;
+}
+
+.field-button {
+  position: absolute;
+  background: rgba(68, 68, 68, 0.8);
+  color: #fff;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.field-button.locked {
+  opacity: 0.5;
+  pointer-events: none;
+}
+


### PR DESCRIPTION
## Summary
- Add world selection screen displaying the world_01 map with field buttons
- Track field accessibility and grey-out locked fields
- Navigate to a new field screen showing chosen field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6cd4fac488321a15040a41b1bde38