### PR TITLE
Add real-time battle step and AI

### DIFF
--- a/src/battle/entities.py
+++ b/src/battle/entities.py
@@ -13,7 +13,7 @@ class Skill:
     range: int  # Manhattan distance
 
 
-@dataclass
+@dataclass(eq=False)
 class Unit:
     """Minimal unit definition for the battle system."""
 
@@ -23,6 +23,9 @@ class Unit:
     position: Tuple[int, int]
     owner: str  # "player" or "enemy"
     skills: List[Skill] = field(default_factory=list)
+
+    # Allow units to be used as dictionary keys based on identity
+    __hash__ = object.__hash__
 
 
 def create_dummy_definitions() -> Tuple[List[Unit], List[Unit]]:

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -23,3 +23,35 @@ def test_attack_and_victory():
         engine.attack(players[0], enemy)
 
     assert engine.check_victory() == "player"
+
+
+def test_real_time_combat():
+    players, enemies = create_dummy_definitions()
+    # position enemies adjacent to the hero for immediate action
+    enemies[0].position = (4, 2)
+    enemies[1].position = (5, 3)
+    # boost hero HP to survive multiple hits and reduce enemy HP for a quick battle
+    players[0].hp = 50
+    enemies[0].hp = 20
+    enemies[1].hp = 20
+    engine = BattleEngine.start_battle(players, enemies)
+
+    # Step 1: hero attacks goblin, enemies retaliate
+    engine.real_time_step({players[0]: ("attack", enemies[0])})
+    assert enemies[0].hp == 10
+    assert players[0].hp == 30
+
+    # Step 2: hero finishes goblin, orc attacks
+    engine.real_time_step({players[0]: ("attack", enemies[0])})
+    assert enemies[0] not in engine.field.all_units()
+    assert players[0].hp == 20
+
+    # Step 3: hero attacks orc, orc counterattacks
+    engine.real_time_step({players[0]: ("attack", enemies[1])})
+    assert enemies[1].hp == 10
+    assert players[0].hp == 10
+
+    # Step 4: hero defeats orc and wins the battle
+    engine.real_time_step({players[0]: ("attack", enemies[1])})
+    status = engine.battle_status()
+    assert status["winner"] == "player"


### PR DESCRIPTION
## Summary
- Add battle setup helper that populates the field from formations
- Introduce real-time combat step with simple enemy AI
- Expose battle status reporting and make units usable as dict keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d2c07cc0832198b965d0befcc87c