### PR TITLE
Fix stage navigation and background sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
       <img id="field-image" alt="field">
       <div id="stage-buttons" class="stage-buttons"></div>
       <button class="back-button" data-target="world-screen">ワールドに戻る</button>
+      <button class="back-button" data-target="menu-screen">メニューに戻る</button>
     </section>
 
     <section id="units-screen" class="screen">
@@ -86,7 +87,8 @@
           <button id="save-formation">保存</button>
           <button id="reset-formation">リセット</button>
           <button id="battle-start" data-target="battle-screen">バトル開始</button>
-          <button class="back-button" data-target="units-screen">戻る</button>
+          <button id="formation-back" class="back-button" data-target="units-screen">戻る</button>
+          <button class="back-button" data-target="menu-screen">メニューに戻る</button>
         </div>
       </div>
       <div class="formation-main">

--- a/main.js
+++ b/main.js
@@ -37,6 +37,14 @@ document.addEventListener('DOMContentLoaded', () => {
   initMenuUnits();
   initFormationScreen();
   initWorldScreen();
+
+  const formationBtn = document.getElementById('formation-button');
+  const formationBack = document.getElementById('formation-back');
+  if (formationBtn && formationBack) {
+    formationBtn.addEventListener('click', () => {
+      formationBack.setAttribute('data-target', 'units-screen');
+    });
+  }
 });
 
 function setRandomMenuBackground() {
@@ -666,6 +674,8 @@ function selectStage(fieldId, stageNumber) {
   if (formationField) {
     formationField.style.backgroundImage = `url(images/stages/stage_${num}.png)`;
   }
+  const backBtn = document.getElementById('formation-back');
+  if (backBtn) backBtn.setAttribute('data-target', 'field-screen');
   if (window.loadFormationGrid) window.loadFormationGrid();
   loadEnemyFormation(stageNumber);
   window.showScreen('formation-screen');
@@ -761,6 +771,8 @@ function endBattle(victory) {
   const nextBtn = document.getElementById('next-stage-button');
 
   retryBtn.onclick = () => {
+    const backBtn = document.getElementById('formation-back');
+    if (backBtn) backBtn.setAttribute('data-target', 'field-screen');
     window.showScreen('formation-screen');
   };
   fieldBtn.onclick = () => {

--- a/style.css
+++ b/style.css
@@ -308,7 +308,7 @@ html, body {
   align-items: flex-start;
   justify-content: flex-start;
   background-image: url('images/fields/01.png');
-  background-size: cover;
+  background-size: 100% 100%;
 }
 
 .formation-top {
@@ -368,7 +368,7 @@ html, body {
   position: relative;
   width: 960px;
   height: 100%;
-  background-size: cover;
+  background-size: 100% 100%;
 }
 
 #formation-grid {
@@ -526,7 +526,7 @@ html, body {
   width: 100%;
   height: 100%;
   background-image: url('images/stages/world_01.png');
-  background-size: cover;
+  background-size: 100% 100%;
 }
 
 .field-button {
@@ -542,6 +542,21 @@ html, body {
 .field-button.locked {
   opacity: 0.5;
   pointer-events: none;
+}
+
+#field-screen {
+  position: relative;
+  justify-content: flex-start;
+}
+
+#field-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+  z-index: -1;
 }
 
 #result-summary {


### PR DESCRIPTION
## Summary
- Stretch world, field and stage backgrounds to fill the screen
- Ensure field screen shows stage buttons and add return-to-menu navigation
- Add back and menu buttons to formation screen with correct target handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d603643c8321b83925a5f59e251d