### PR TITLE
feat: add field background and island button

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,12 @@
 
     <section id="field-screen" class="screen">
       <h2 id="field-name"></h2>
-      <img id="field-image" alt="field">
+      <button id="field-image-button" class="field-image-button" aria-label="ステージ1へ"></button>
       <div id="stage-buttons" class="stage-buttons"></div>
-      <button class="back-button" data-target="world-screen">ワールドに戻る</button>
-      <button class="back-button" data-target="menu-screen">メニューに戻る</button>
+      <div class="field-back-buttons">
+        <button class="back-button" data-target="world-screen">ワールドに戻る</button>
+        <button class="back-button" data-target="menu-screen">メニューに戻る</button>
+      </div>
     </section>
 
     <section id="units-screen" class="screen">

--- a/main.js
+++ b/main.js
@@ -641,10 +641,15 @@ function selectField(id, name) {
   currentField = Number(id);
   currentStage = null;
   const num = String(id).padStart(2, '0');
-  const img = document.getElementById('field-image');
+  const fieldScreen = document.getElementById('field-screen');
   const title = document.getElementById('field-name');
-  if (img) img.src = `images/stages/field_${num}.png`;
+  if (fieldScreen) {
+    fieldScreen.style.backgroundImage = `url(images/stages/field_${num}.png)`;
+    fieldScreen.style.backgroundSize = '100% 100%';
+  }
   if (title) title.textContent = name;
+  const islandBtn = document.getElementById('field-image-button');
+  if (islandBtn) islandBtn.onclick = () => selectStage(currentField, 1);
   renderStageButtons(currentField);
   window.showScreen('field-screen');
 }

--- a/style.css
+++ b/style.css
@@ -547,16 +547,32 @@ html, body {
 #field-screen {
   position: relative;
   justify-content: flex-start;
+  background-size: 100% 100%;
 }
 
-#field-image {
+.field-image-button {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  object-fit: fill;
-  z-index: -1;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.stage-buttons {
+  position: relative;
+  z-index: 2;
+}
+
+.field-back-buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  position: relative;
+  z-index: 2;
 }
 
 #result-summary {


### PR DESCRIPTION
## Summary
- show field image as full-size background after selecting a world
- add clickable island button and side-by-side back buttons

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6da0dadbc8321959c6b95b9985255