### PR TITLE
Add obstacle support and restrict movement directions

### DIFF
--- a/src/battle/engine.py
+++ b/src/battle/engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from .entities import Skill, Unit
 from .grid import BattleField
@@ -18,13 +18,18 @@ class BattleEngine:
         self.turn_logs: List[str] = []
 
     @classmethod
-    def start_battle(cls, players: List[Unit], enemies: List[Unit]) -> "BattleEngine":
+    def start_battle(
+        cls,
+        players: List[Unit],
+        enemies: List[Unit],
+        obstacles: Optional[Set[Tuple[int, int]]] = None,
+    ) -> "BattleEngine":
         """Create a battle engine with units placed on the field.
 
         The units are expected to already have positions assigned based on
         formation screen selections.
         """
-        field = BattleField()
+        field = BattleField(obstacles)
         for unit in players + enemies:
             field.add_unit(unit)
         engine = cls(field)
@@ -78,8 +83,10 @@ class BattleEngine:
             self._after_action()
 
     def move(self, unit: Unit, dx: int, dy: int) -> None:
-        new_pos = (unit.position[0] + dx, unit.position[1] + dy)
         try:
+            if (dx, dy) not in {(-1, 0), (1, 0), (0, -1), (0, 1)}:
+                raise ValueError("Invalid movement vector")
+            new_pos = (unit.position[0] + dx, unit.position[1] + dy)
             self.field.move_unit(unit, new_pos)
             self.turn_logs.append(f"{unit.name} moved to {new_pos}")
         except ValueError:

--- a/src/battle/grid.py
+++ b/src/battle/grid.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from .entities import Unit
 
@@ -13,8 +13,9 @@ class BattleField:
     ENEMY_BASE = (0, 2)
     PLAYER_BASE = (6, 2)
 
-    def __init__(self) -> None:
+    def __init__(self, obstacles: Optional[Set[Tuple[int, int]]] = None) -> None:
         self._units: Dict[Tuple[int, int], Unit] = {}
+        self.obstacles: Set[Tuple[int, int]] = set(obstacles or [])
 
     # Grid utilities -----------------------------------------------------
     def in_bounds(self, pos: Tuple[int, int]) -> bool:
@@ -31,14 +32,14 @@ class BattleField:
     def add_unit(self, unit: Unit) -> None:
         if not self.in_bounds(unit.position):
             raise ValueError("Position out of bounds")
-        if self.unit_at(unit.position):
+        if self.unit_at(unit.position) or unit.position in self.obstacles:
             raise ValueError("Cell already occupied")
         self._units[unit.position] = unit
 
     def move_unit(self, unit: Unit, new_pos: Tuple[int, int]) -> None:
         if not self.in_bounds(new_pos):
             raise ValueError("Position out of bounds")
-        if self.unit_at(new_pos):
+        if self.unit_at(new_pos) or new_pos in self.obstacles:
             raise ValueError("Cell already occupied")
         del self._units[unit.position]
         unit.position = new_pos

--- a/tests/test_battle.py
+++ b/tests/test_battle.py
@@ -1,6 +1,8 @@
 import pathlib
 import sys
 
+import pytest
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from src.battle import BattleEngine, BattleField, create_dummy_definitions
@@ -79,3 +81,32 @@ def test_turn_order_and_take_turn():
     assert hero.name == "Hero"
     engine.take_turn(hero, "attack", enemies[0])
     assert enemies[0] in engine.graveyard
+
+
+def test_obstacles_and_movement_rules():
+    players, enemies = create_dummy_definitions()
+    field = BattleField({(4, 2)})
+    field.add_unit(players[0])
+
+    with pytest.raises(ValueError):
+        field.move_unit(players[0], (4, 2))
+
+    engine = BattleEngine.start_battle(players, enemies, obstacles={(4, 2)})
+    hero = players[0]
+
+    assert (4, 2) in engine.field.obstacles
+
+    # invalid vector
+    engine.move(hero, 1, 1)
+    assert hero.position == (5, 2)
+    assert engine.turn_logs[-1] == "Hero failed to move"
+
+    # blocked by obstacle
+    engine.move(hero, -1, 0)
+    assert hero.position == (5, 2)
+    assert engine.turn_logs[-1] == "Hero failed to move"
+
+    # valid move
+    engine.move(hero, 1, 0)
+    assert hero.position == (6, 2)
+    assert engine.turn_logs[-1] == "Hero moved to (6, 2)"


### PR DESCRIPTION
## Summary
- Track impassable obstacle coordinates on the battlefield
- Allow battle setup to provide obstacle positions
- Limit movement commands to cardinal directions and block moves into obstacles
- Test obstacle handling and movement validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e008415c83219797f8114eb32dcd