### PR TITLE
Add pass and surrender actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,8 @@
       <h2>バトル</h2>
       <button class="back-button" data-target="menu-screen">メニューに戻る</button>
       <button id="attack-button">攻撃</button>
+      <button id="pass-button">パス</button>
+      <button id="surrender-button">降参</button>
       <div id="battle-grid"></div>
       <div id="battle-message" class="hidden"></div>
       <div id="skill-modal" class="modal hidden">

--- a/main.js
+++ b/main.js
@@ -791,6 +791,25 @@ function initBattle() {
   }
   const attackBtn = document.getElementById('attack-button');
   if (attackBtn) attackBtn.onclick = showSkillModal;
+  const passBtn = document.getElementById('pass-button');
+  if (passBtn)
+    passBtn.onclick = () => {
+      if (!currentAttacker) return;
+      if (battleEngine && typeof battleEngine.pass_turn === 'function') {
+        battleEngine.pass_turn(currentAttacker);
+      }
+      if (battleEngine && typeof battleEngine.next_unit === 'function') {
+        currentAttacker = battleEngine.next_unit();
+      }
+    };
+  const surrenderBtn = document.getElementById('surrender-button');
+  if (surrenderBtn)
+    surrenderBtn.onclick = () => {
+      if (battleEngine && typeof battleEngine.end_battle === 'function') {
+        battleEngine.end_battle(false);
+      }
+      endBattle(false);
+    };
 }
 
 function showSkillModal() {

--- a/src/battle/engine.py
+++ b/src/battle/engine.py
@@ -169,6 +169,17 @@ class BattleEngine:
         status["winner"] = self.check_victory()
         return status
 
+    def end_battle(self, victory: bool) -> None:
+        """Forcefully end the battle with the given result.
+
+        Clearing the turn order prevents any further actions and records the
+        outcome in the turn logs so callers can display an appropriate result
+        screen.
+        """
+        winner = "player" if victory else "enemy"
+        self.turn_logs.append(f"{winner} wins!")
+        self.order.clear()
+
     # Internal helpers --------------------------------------------------
     def _update_base_control(self) -> None:
         player_unit = self.field.unit_at(BattleField.ENEMY_BASE)


### PR DESCRIPTION
## Summary
- Add pass and surrender buttons to battle screen
- Handle passing turns and surrendering in `main.js`
- Implement `BattleEngine.end_battle` for forced battle termination

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e55157f48321b79c47cfe9389ecf