### PR TITLE
Add unit rendering and turn updates

### DIFF
--- a/battle.js
+++ b/battle.js
@@ -1,0 +1,25 @@
+function renderUnits() {
+  const grid = document.getElementById('battle-grid');
+  if (!grid) return;
+  // clear existing units
+  const cells = Array.from(grid.querySelectorAll('.cell'));
+  cells.forEach(cell => {
+    cell.innerHTML = '';
+  });
+  if (!battleEngine || !battleEngine.field || typeof battleEngine.field.all_units !== 'function') return;
+  const units = battleEngine.field.all_units();
+  units.forEach(unit => {
+    if (!unit || !unit.position) return;
+    const [x, y] = unit.position;
+    const cell = cells.find(c => Number(c.dataset.x) === x && Number(c.dataset.y) === y);
+    if (!cell) return;
+    const img = document.createElement('img');
+    if (unit.image) {
+      img.src = unit.image;
+    }
+    const ownerClass = unit.owner === 'player' ? 'player-unit' : 'enemy-unit';
+    img.classList.add(ownerClass);
+    cell.appendChild(img);
+  });
+}
+window.renderUnits = renderUnits;

--- a/index.html
+++ b/index.html
@@ -154,6 +154,7 @@
     </section>
   </div>
   <div id="logs"></div>
+  <script src="battle.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -819,6 +819,7 @@ function initBattle() {
   if (battleEngine && typeof battleEngine.next_unit === 'function') {
     currentAttacker = battleEngine.next_unit();
   }
+  renderUnits();
   const attackBtn = document.getElementById('attack-button');
   if (attackBtn) attackBtn.onclick = showSkillModal;
   const passBtn = document.getElementById('pass-button');
@@ -831,6 +832,7 @@ function initBattle() {
       if (battleEngine && typeof battleEngine.next_unit === 'function') {
         currentAttacker = battleEngine.next_unit();
       }
+      renderUnits();
     };
   const surrenderBtn = document.getElementById('surrender-button');
   if (surrenderBtn)
@@ -895,6 +897,10 @@ function handleTargetSelect(x, y) {
   if (battleEngine && typeof battleEngine.attack === 'function') {
     battleEngine.attack(currentAttacker, target, pendingSkill);
   }
+  if (battleEngine && typeof battleEngine.next_unit === 'function') {
+    currentAttacker = battleEngine.next_unit();
+  }
+  renderUnits();
   pendingSkill = null;
 }
 


### PR DESCRIPTION
## Summary
- add `renderUnits` helper to place unit images on the battle grid
- update battle flow to call `renderUnits` on init and after each turn
- load new helper via `battle.js`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6eb8f977083218d0a2e1cbd0d64bf