### PR TITLE
feat: add turn processing

### DIFF
--- a/battle.js
+++ b/battle.js
@@ -23,3 +23,67 @@ function renderUnits() {
   });
 }
 window.renderUnits = renderUnits;
+
+function enemyTurn(unit) {
+  if (!battleEngine || !unit) return;
+  if (!battleEngine.field || typeof battleEngine.field.all_units !== 'function') {
+    return;
+  }
+  const units = battleEngine.field.all_units();
+  const players = units.filter(u => u.owner === 'player');
+  if (players.length === 0) {
+    if (typeof battleEngine.pass_turn === 'function') {
+      battleEngine.pass_turn(unit);
+    }
+    return;
+  }
+  let target = players[0];
+  let minDist =
+    Math.abs(target.position[0] - unit.position[0]) +
+    Math.abs(target.position[1] - unit.position[1]);
+  for (let i = 1; i < players.length; i++) {
+    const p = players[i];
+    const dist =
+      Math.abs(p.position[0] - unit.position[0]) +
+      Math.abs(p.position[1] - unit.position[1]);
+    if (dist < minDist) {
+      minDist = dist;
+      target = p;
+    }
+  }
+  const skill = unit.skills && unit.skills[0];
+  if (skill && minDist <= skill.range) {
+    if (typeof battleEngine.attack === 'function') {
+      battleEngine.attack(unit, target, skill);
+    }
+  } else {
+    let dx = 0;
+    let dy = 0;
+    if (target.position[0] !== unit.position[0]) {
+      dx = target.position[0] > unit.position[0] ? 1 : -1;
+    } else if (target.position[1] !== unit.position[1]) {
+      dy = target.position[1] > unit.position[1] ? 1 : -1;
+    }
+    try {
+      if (typeof battleEngine.move === 'function') {
+        battleEngine.move(unit, dx, dy);
+      }
+    } catch (e) {
+      if (typeof battleEngine.pass_turn === 'function') {
+        battleEngine.pass_turn(unit);
+      }
+    }
+  }
+  renderUnits();
+}
+
+function processTurn() {
+  if (!battleEngine || typeof battleEngine.next_unit !== 'function') return;
+  currentAttacker = battleEngine.next_unit();
+  renderUnits();
+  if (currentAttacker && currentAttacker.owner === 'enemy') {
+    enemyTurn(currentAttacker);
+    processTurn();
+  }
+}
+window.processTurn = processTurn;

--- a/main.js
+++ b/main.js
@@ -816,10 +816,9 @@ function initBattle() {
     }
   }
   battleEngine = window.battleEngine || battleEngine;
-  if (battleEngine && typeof battleEngine.next_unit === 'function') {
-    currentAttacker = battleEngine.next_unit();
+  if (typeof processTurn === 'function') {
+    processTurn();
   }
-  renderUnits();
   const attackBtn = document.getElementById('attack-button');
   if (attackBtn) attackBtn.onclick = showSkillModal;
   const passBtn = document.getElementById('pass-button');
@@ -829,10 +828,9 @@ function initBattle() {
       if (battleEngine && typeof battleEngine.pass_turn === 'function') {
         battleEngine.pass_turn(currentAttacker);
       }
-      if (battleEngine && typeof battleEngine.next_unit === 'function') {
-        currentAttacker = battleEngine.next_unit();
+      if (typeof processTurn === 'function') {
+        processTurn();
       }
-      renderUnits();
     };
   const surrenderBtn = document.getElementById('surrender-button');
   if (surrenderBtn)
@@ -897,11 +895,10 @@ function handleTargetSelect(x, y) {
   if (battleEngine && typeof battleEngine.attack === 'function') {
     battleEngine.attack(currentAttacker, target, pendingSkill);
   }
-  if (battleEngine && typeof battleEngine.next_unit === 'function') {
-    currentAttacker = battleEngine.next_unit();
-  }
-  renderUnits();
   pendingSkill = null;
+  if (typeof processTurn === 'function') {
+    processTurn();
+  }
 }
 
 function showBattleMessage(msg) {


### PR DESCRIPTION
## Summary
- add `processTurn` to control turn order and enemy AI
- update battle setup and actions to use `processTurn`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6eca70b188321b3bdf9988ade43ec