### PR TITLE
Delay battle screen until battle initialization completes

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         <div class="formation-actions">
           <button id="save-formation">保存</button>
           <button id="reset-formation">リセット</button>
-          <button id="battle-start" data-target="battle-screen">バトル開始</button>
+          <button id="battle-start">バトル開始</button>
           <button id="formation-back" class="back-button" data-target="units-screen">戻る</button>
           <button class="back-button" data-target="menu-screen">メニューに戻る</button>
         </div>

--- a/main.js
+++ b/main.js
@@ -51,14 +51,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const battleStart = document.getElementById('battle-start');
   if (battleStart) {
-    battleStart.addEventListener('click', () => {
+    battleStart.addEventListener('click', async () => {
       const num = String(currentStage).padStart(2, '0');
       const battleScreen = document.getElementById('battle-screen');
       if (battleScreen) {
         battleScreen.style.backgroundImage = `url(images/stages/stage_${num}.png)`;
       }
+      await initBattle();
       window.showScreen('battle-screen');
-      initBattle();
     });
   }
 


### PR DESCRIPTION
## Summary
- Remove generic navigation from the battle-start button
- Wait for `initBattle` to finish before showing the battle screen

## Testing
- `pytest`
- `NODE_PATH=/tmp/jsdom/node_modules node <<'NODE'
const fs=require('fs');
const path=require('path');
const {JSDOM}=require('jsdom');
const base=process.cwd();
const html=fs.readFileSync(path.join(base,'index.html'),'utf8');
const dom=new JSDOM(html,{runScripts:'dangerously',resources:'usable',url:'file://'+path.join(base,'index.html'),pretendToBeVisual:true,beforeParse(window){window.fetch=()=>Promise.resolve({json:()=>Promise.resolve({units:[],skills:[],boss_skills:{skills:[]}})});Object.defineProperty(window,'localStorage',{value:{getItem(){return null;},setItem(){},removeItem(){}},configurable:true});}});
dom.window.addEventListener('DOMContentLoaded',()=>{const button=dom.window.document.getElementById('battle-start');let initCount=0;dom.window.initBattle=()=>{initCount++;};const screenCalls=[];dom.window.showScreen=id=>{screenCalls.push(id);};button.click();setTimeout(()=>{console.log('initCount',initCount);console.log('screenCalls',screenCalls);},0);});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b6ef9f15188321839481b3282b87d0