### PR TITLE
Ensure enemy units fill container height

### DIFF
--- a/style.css
+++ b/style.css
@@ -513,6 +513,10 @@ html, body {
   object-fit: contain;
 }
 
+.enemy-unit {
+  height: 100%;
+}
+
 .player-unit {
   transform: scaleX(-1);
 }


### PR DESCRIPTION
## Summary
- Add CSS rule to make enemy unit images fill their container height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b83708566883219ee0389c0ed96e99